### PR TITLE
fix: building on 386 caused an INT overrun

### DIFF
--- a/changelog/fragments/fix-int.yaml
+++ b/changelog/fragments/fix-int.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Previous build attempt failed on an int overrun on 386 arch build.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/get-next-semver.yaml
+++ b/changelog/fragments/get-next-semver.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Added get dh-tags --next to retrieve the next SemVer based on the highest
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/cmd/objects/dhtags.go
+++ b/cmd/objects/dhtags.go
@@ -186,11 +186,12 @@ func lenReadable(length int, decimals int) (out string) {
 	var remainder int
 
 	// Get whole number, and the remainder for decimals
-	if length > TB {
-		unit = "TB"
-		i = length / TB
-		remainder = length - (i * TB)
-	} else if length > GB {
+	// if length > TB {
+	// unit = "TB"
+	// i = length / TB
+	// remainder = length - (i * TB)
+	// } else if length > GB {
+	if length > GB {
 		unit = "GB"
 		i = length / GB
 		remainder = length - (i * GB)


### PR DESCRIPTION
The previous build failed when converting to TB, GB, MB, etc.  Simply removed the convertion to TB, hopefully we don't have any TB sized docker files...

**Description of the change:**

Removed the TB conversion
Added a "get dh-tags --next" to retrieve the next SemVer

**Motivation for the change:**

Replace this:

```groovy
                existing_version_major = sh returnStdout: true, script: "wget -q https://hub.docker.com/v2/repositories/splicemachine/splicedb-operator/tags?page=$page_num -O - | jq -r '.results[].name' | grep '$branch_name-' | cut -d '.' -f1 | sed 's/\"//g' | sed 's/,//g' | head -n 1 | cut -d ' ' -f8 | sed 's/$branch_name-//g' | tr -d '\n'"
                existing_version_minor = sh returnStdout: true, script: "wget -q https://hub.docker.com/v2/repositories/splicemachine/splicedb-operator/tags?page=$page_num -O - | jq -r '.results[].name' | grep '$branch_name-' | cut -d '.' -f2 | sed 's/\"//g' | sed 's/,//g' | head -n 1 | sed 's/$branch_name-//g' | tr -d '\n'"
                existing_version_hotfix = sh returnStdout: true, script: "wget -q https://hub.docker.com/v2/repositories/splicemachine/splicedb-operator/tags?page=$page_num -O - | jq -r '.results[].name' | grep '$branch_name-' | cut -d '.' -f3 | sed 's/\"//g' | sed 's/,//g' | head -n 1 | sed 's/$branch_name-//g' | sed 's/[^0-9]*//g' | tr -d '\n'"
```

With a single call.

`splice-cloud-util get dh-tags --org splicemachine --repo splicedb-operator --prefix 'dev-' --next`

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/splicemaahs/splice-cloud-util/tree/master/changelog/fragments/00-template.yaml))

  - It is important to include the changelog fragment in your PR, this way the changelog will include the correct PR link.
