### PR TITLE
fix: move requirements check to commands (DBAAS-5118)

### DIFF
--- a/changelog/fragments/move-requirements.yaml
+++ b/changelog/fragments/move-requirements.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Move the logic for detecting credentials to each routine from main/root
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/cmd/get_certapicreds.go
+++ b/cmd/get_certapicreds.go
@@ -26,6 +26,12 @@ var getCmdCertAPICreds = &cobra.Command{
 	#> splice-cloud-util get certapicreds
 
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Check our Jenkins Stored Credentials
+		if err := validateJenkins(); err != nil {
+			logrus.Fatal("Unable to access Jenkins, please run 'splice-cloud-util init' to configure Jenkins access")
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		err := getCertAPICreds(outputFormat)

--- a/cmd/get_environments.go
+++ b/cmd/get_environments.go
@@ -31,6 +31,12 @@ EXAMPLE 3
 	#> splice-cloud-util get environment --csp gcp
 
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Check our Jenkins Stored Credentials
+		if err := validateJenkins(); err != nil {
+			logrus.Fatal("Unable to access Jenkins, please run 'splice-cloud-util init' to configure Jenkins access")
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		csp, _ := cmd.Flags().GetString("csp")

--- a/cmd/get_repositories.go
+++ b/cmd/get_repositories.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	// "github.com/hashicorp/vault/api"
@@ -46,6 +47,12 @@ EXAMPLE 2
 
 	#> splice-cloud-util get dh-repositories --org splicemachine --add-release --add-updated
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if dockerUser == "" || dockerPass == "" {
+			logrus.Info("Unable to locate Docker login credentials, please run 'splice-cloud-util init' to configure access.")
+			os.Exit(1)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		org, _ := cmd.Flags().GetString("org")
 		addUpdated, _ := cmd.Flags().GetBool("add-updated")

--- a/cmd/get_tags.go
+++ b/cmd/get_tags.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"splice-cloud-util/cmd/objects"
 	"strings"
 
@@ -26,6 +27,12 @@ EXAMPLE 2
 
 	#> splice-cloud-util get dh-tags --org splicemachine --repo sm_k8_splicectlapi --top 5
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if dockerUser == "" || dockerPass == "" {
+			logrus.Info("Unable to locate Docker login credentials, please run 'splice-cloud-util init' to configure access.")
+			os.Exit(1)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		org, _ := cmd.Flags().GetString("org")
 		repo, _ := cmd.Flags().GetString("repo")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,10 +68,6 @@ var rootCmd = &cobra.Command{
 				dockerPass = dp.(string)
 			}
 		}
-		if dockerUser == "" || dockerPass == "" {
-			logrus.Info("Please pass in --user and --pass to set your Docker login credentials, these will be saved in the ~/dockerhub-util/config.yaml file")
-			os.Exit(1)
-		}
 		// Validate global parameters here, BEFORE we start to waste time
 		// and run any code.
 		if outputFormat != "" {
@@ -94,12 +90,6 @@ var rootCmd = &cobra.Command{
 
 		vaultClient = vault.NewVault()
 
-		if os.Args[1] != "init" {
-			// Check our Jenkins Stored Credentials
-			if err := validateJenkins(); err != nil {
-				logrus.Fatal("Unable to access Jenkins, please run 'splice-cloud-util init' to configure Jenkins access")
-			}
-		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 	},


### PR DESCRIPTION
**Description of the change:**

Moved the requirements checks to each command preRun

**Motivation for the change:**

If you don't need access to one of the systems it would fail if you hadn't provided credentials.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/splicemaahs/splice-cloud-util/tree/master/changelog/fragments/00-template.yaml))

  - It is important to include the changelog fragment in your PR, this way the changelog will include the correct PR link.
