### PR TITLE
feat: plain semver or with prefix- (DBAAS-5118)

### DIFF
--- a/changelog/fragments/semver-options.yaml
+++ b/changelog/fragments/semver-options.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Create an option to return the SemVer with the prefix added back in, otherwise just the SemVer.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/cmd/get_tags.go
+++ b/cmd/get_tags.go
@@ -37,11 +37,12 @@ EXAMPLE 2
 		org, _ := cmd.Flags().GetString("org")
 		repo, _ := cmd.Flags().GetString("repo")
 		prefix, _ := cmd.Flags().GetString("prefix")
+		returnPrefix, _ := cmd.Flags().GetBool("return-prefix")
 		top, _ := cmd.Flags().GetInt("top")
 		next, _ := cmd.Flags().GetBool("next")
 
 		if next {
-			nextSemVer, err := getNextDockerHubRepositoryTag(org, repo, prefix)
+			nextSemVer, err := getNextDockerHubRepositoryTag(org, repo, prefix, returnPrefix)
 			if err != nil {
 				logrus.WithError(err).Error("Error getting next SemVer")
 			}
@@ -71,7 +72,7 @@ EXAMPLE 2
 	},
 }
 
-func getNextDockerHubRepositoryTag(org string, repo string, prefix string) (string, error) {
+func getNextDockerHubRepositoryTag(org string, repo string, prefix string, returnPrefix bool) (string, error) {
 
 	token, err := getToken()
 	if err != nil {
@@ -133,7 +134,7 @@ func getNextDockerHubRepositoryTag(org string, repo string, prefix string) (stri
 	}
 
 	maxSemVer.Patch++
-	if len(prefix) > 0 {
+	if len(prefix) > 0 && returnPrefix {
 		return fmt.Sprintf("%s%s", prefix, maxSemVer.String()), nil
 	}
 	return maxSemVer.String(), nil
@@ -203,6 +204,7 @@ func init() {
 	getTagsCmd.Flags().String("org", "", "Specify the dockerhub organization")
 	getTagsCmd.Flags().String("repo", "", "Specify the dockerhub repository")
 	getTagsCmd.Flags().String("prefix", "", "Specify the prefix for the tag")
+	getTagsCmd.Flags().BoolP("return-prefix", "r", false, "Return the prefix as part of the SemVer output")
 	getTagsCmd.Flags().Int("top", 0, "Specify the top number of TAGs to return")
 	getTagsCmd.Flags().BoolP("next", "n", false, "Get the next valid SEMVER based on the highest one")
 	getTagsCmd.MarkFlagRequired("org")


### PR DESCRIPTION
**Description of the change:**

splicedb-operator requires a plain SemVer, was initially returning with the prefix (branch-{semver}) which was incorrect.

**Motivation for the change:**

Failing build via Jenkinsfile

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/splicemaahs/splice-cloud-util/tree/master/changelog/fragments/00-template.yaml))

  - It is important to include the changelog fragment in your PR, this way the changelog will include the correct PR link.
